### PR TITLE
Accounting for things through petalburg woods

### DIFF
--- a/calc/src/field.ts
+++ b/calc/src/field.ts
@@ -82,6 +82,7 @@ export class Side implements State.Side {
   cannonade: boolean;
   volcalith: boolean;
   isSR: boolean;
+  isStickyWebs: boolean;
   isReflect: boolean;
   isLightScreen: boolean;
   isProtected: boolean;
@@ -104,6 +105,7 @@ export class Side implements State.Side {
     this.cannonade = !!side.cannonade;
     this.volcalith = !!side.volcalith;
     this.isSR = !!side.isSR;
+    this.isStickyWebs = !!side.isStickyWebs;
     this.isReflect = !!side.isReflect;
     this.isLightScreen = !!side.isLightScreen;
     this.isProtected = !!side.isProtected;

--- a/calc/src/state.ts
+++ b/calc/src/state.ts
@@ -61,6 +61,7 @@ export namespace State {
     cannonade?: boolean;
     volcalith?: boolean;
     isSR?: boolean;
+    isStickyWebs?: boolean;
     isReflect?: boolean;
     isLightScreen?: boolean;
     isProtected?: boolean;

--- a/src/extensions/simulator/battle-field-state-builder.ts
+++ b/src/extensions/simulator/battle-field-state-builder.ts
@@ -2,7 +2,7 @@ import { Field, Pokemon } from "@smogon/calc";
 import type { SetCollectionData } from "../core/storage.contracts";
 import { BattleFieldState, CpuTrainer, PlayerTrainer } from "./moveScoring.contracts";
 import { gen } from "../configuration";
-import { Trainers } from "../trainer-sets";
+import { OpposingTrainer } from "../trainer-sets";
 
 export class BattleFieldStateBuilder {
     public static buildTrainerBattle(player: SetCollectionData, cpu: string): BattleFieldState {
@@ -23,7 +23,7 @@ export class BattleFieldStateBuilder {
 
         return new BattleFieldState(
             new PlayerTrainer([], playerPokes),
-            new CpuTrainer([], Trainers[cpu]),
+            new CpuTrainer([], OpposingTrainer(cpu]),
             new Field());
     }
 }

--- a/src/extensions/simulator/battle-field-state-visitor.ts
+++ b/src/extensions/simulator/battle-field-state-visitor.ts
@@ -1,5 +1,6 @@
 import { Field, Pokemon, Side } from "@smogon/calc";
 import { BattleFieldState, PokemonPosition, Trainer } from "./moveScoring.contracts";
+import { getFinalSpeed } from "./utils";
 
 export interface IBattleFieldStateVisitor {
     visitActivePokemon?(state: BattleFieldState, pokemon: PokemonPosition, field: Field, side: Side): void;
@@ -18,7 +19,11 @@ export function visitActivePokemonInSpeedOrder(state: BattleFieldState, visitor:
         toVisit.push({ active, field: state.field, side: state.cpuSide });
     }
 
-    toVisit.sort((a,b) => b.active.pokemon.stats.spe - a.active.pokemon.stats.spe);
+    toVisit.sort((a,b) => {
+        let aSpeed = getFinalSpeed(a.active.pokemon, a.field, a.side);
+        let bSpeed = getFinalSpeed(b.active.pokemon, b.field, b.side);
+        return bSpeed - aSpeed;
+    });
 
     for (let visit of toVisit)
         visitor.visitActivePokemon(state, visit.active, visit.field, visit.side);

--- a/src/extensions/simulator/helper.ts
+++ b/src/extensions/simulator/helper.ts
@@ -47,6 +47,26 @@ interface Gen {
   Side: typeof side;
 }
 
+export type LegacyStatsTable = {
+  hp?: number;
+  at?: number;
+  df?: number;
+  sa?: number;
+  sd?: number;
+  sp?: number;
+};
+
+export function convertStats(legacyStatsFromSet?: LegacyStatsTable): I.StatsTable {
+  return {
+    hp: legacyStatsFromSet?.hp || 31,
+    atk: legacyStatsFromSet?.at || 31,
+    def: legacyStatsFromSet?.df || 31,
+    spa: legacyStatsFromSet?.sa || 31,
+    spd: legacyStatsFromSet?.sd || 31,
+    spe: legacyStatsFromSet?.sp || 31,
+  }
+}
+
 export function inGen(gen: I.GenerationNum, fn: (gen: Gen) => void) {
   fn({
     gen,

--- a/src/extensions/simulator/moveScore.ts
+++ b/src/extensions/simulator/moveScore.ts
@@ -30,7 +30,7 @@ export class MoveScore {
     }
 
     public never(percentChance?: number): void {
-        this.setScore(-999, percentChance);
+        this.setScore(-50, percentChance);
     }
 
     public setScore(newScore: number, percentChance: number = 1): void {

--- a/src/extensions/simulator/moveScoring.spec.ts
+++ b/src/extensions/simulator/moveScoring.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '@smogon/calc';
 import { inGen, importTeam } from './test-helper';
 import { megaEvolve } from './moveScoring';
-import { Trainers } from '../trainer-sets';
+import { OpposingTrainer } from '../trainer-sets';
 
 const RunAndBun = 8;
 inGen(RunAndBun, ({ gen, calculate, Pokemon, Move }) => {

--- a/src/extensions/simulator/path-finder.ts
+++ b/src/extensions/simulator/path-finder.ts
@@ -167,23 +167,25 @@ export function printDecisionTree(tree: DecisionNode | null, indent: string = ''
     let output = '';
     
     // Print the player action
-    output += indent + tree.playerAction + '\n';
+    // output += indent + tree.playerAction + '\n';
     
     // Get CPU outcomes
     const outcomes = Array.from(tree.cpuOutcomes.entries());
     
     if (outcomes.length === 0) {
+        output += indent + tree.playerAction + '\n';
         return output;
     }
     
     // If there's only one CPU outcome, don't use if/else
     if (outcomes.length === 1) {
         const [cpuAction, nextNode] = outcomes[0];
-        output += indent + cpuAction + '\n';
         
         if (nextNode === 'WIN') {
+            output += indent + tree.playerAction + '\n';
             output += indent + 'WIN\n';
         } else {
+            output += indent + nextNode.state.history.map(h => h.description).join(`\n${indent}`) + '\n';
             output += printDecisionTree(nextNode, indent);
         }
     } else {
@@ -192,6 +194,7 @@ export function printDecisionTree(tree: DecisionNode | null, indent: string = ''
         const probability = (100 / outcomes.length).toFixed(1);
         
         outcomes.forEach(([cpuAction, nextNode], index) => {
+            output += indent + `${tree.playerAction}\n`;
             if (index === 0) {
                 output += indent + `if ${cpuAction} (${probability}%):\n`;
             } else {

--- a/src/extensions/simulator/phases/battle/cpu-move-selection.spec.ts
+++ b/src/extensions/simulator/phases/battle/cpu-move-selection.spec.ts
@@ -12,7 +12,7 @@ import { getCpuMoveScoresAgainstTarget, getCpuPossibleActions } from './cpu-move
 import { get } from 'jquery';
 import { PartyOrderSwitchStrategy } from '../../switchStrategy.partyOrder';
 import { getBox } from '../../playthrough/museum.collection';
-import { Trainers } from '../../../trainer-sets';
+import { OpposingTrainer } from '../../../trainer-sets';
 import { create1v1BattleState } from '../../helper';
 
 const RunAndBun = 8;
@@ -29,18 +29,18 @@ inGen(RunAndBun, ({ gen, calculate, Pokemon, Move }) => {
   Level: 100
   - Stone Edge
   `);
-      player.originalCurHP = 1;
+      player = player.clone({ curHP: 1})
 
       const actions = getCpuActionsFor1v1(cpu, player);
       expect(actions.length).toBe(1);
       expect(actions[0]).toBePossibleAction({
-          type: 'move',
-          pokemon: cpu,
-          move: {
-            move: 'Fake Out',
-            target: { type: 'opponent', slot: 0 }
-          },
-          probability: 1
+        type: 'move',
+        pokemon: cpu,
+        move: {
+          move: 'Fake Out',
+          target: { type: 'opponent', slot: 0 }
+        },
+        probability: 1
       });
     });
 
@@ -61,12 +61,12 @@ inGen(RunAndBun, ({ gen, calculate, Pokemon, Move }) => {
       const actions = getCpuActionsFor1v1(cpuKrabby, playerAerodactyl);
       expect(actions.length).toBe(1);
       expect(actions[0]).toBePossibleAction({
-          type: 'move',
-          pokemon: cpuKrabby,
-          move: {
-            move: 'Crabhammer',
-            target: { type: 'opponent', slot: 0 }
-          },
+        type: 'move',
+        pokemon: cpuKrabby,
+        move: {
+          move: 'Crabhammer',
+          target: { type: 'opponent', slot: 0 }
+        },
         probability: 1
       });
     });
@@ -99,40 +99,40 @@ Ability: Hyper Cutter
 
       // Situation: Krabby is slower than Dragapult and is KOd, but Krabby can KO with priority before it dies.
       const state = new BattleFieldState(
-        new PlayerTrainer([ new PokemonPosition(Torkoal), new PokemonPosition(Dragapult)], []), 
-        new CpuTrainer([ new PokemonPosition(Krabby) ], []), 
+        new PlayerTrainer([new PokemonPosition(Torkoal), new PokemonPosition(Dragapult)], []),
+        new CpuTrainer([new PokemonPosition(Krabby)], []),
         new Field({ gameType: 'Doubles' }));
-        
-      const scores = getCpuMoveScoresAgainstTarget(state, state.cpu.active[0], state.player.active[0], { slot: 0, type: 'opponent'});
+
+      const scores = getCpuMoveScoresAgainstTarget(state, state.cpu.active[0], state.player.active[0], { slot: 0, type: 'opponent' });
       const torkoalActions = getCpuActionsFor1v1(Krabby, Torkoal);
       const dragapultActions = getCpuActionsFor1v1(Krabby, Dragapult);
 
       expect(torkoalActions.length).toBe(1);
       expect(torkoalActions[0]).toBePossibleAction({
-        pokemon: Torkoal,  
+        pokemon: Torkoal,
         type: 'move',
-          move: {
-            move: 'Waterfall',
-            target: { type: 'opponent', slot: 0 }
-          },
+        move: {
+          move: 'Waterfall',
+          target: { type: 'opponent', slot: 0 }
+        },
         probability: 1
       });
 
       expect(dragapultActions.length).toBe(1);
       expect(dragapultActions[0]).toBePossibleAction({
         pokemon: Dragapult,
-          type: 'move',
-          move: {
-            move: 'Aqua Jet',
-            target: { type: 'opponent', slot: 0 }
-          },
+        type: 'move',
+        move: {
+          move: 'Aqua Jet',
+          target: { type: 'opponent', slot: 0 }
+        },
         probability: 1
       });
     });
   });
 
   it("Belch isn't used when holding a berry", () => {
-    const [, Croagunk,] = Trainers['Team Aqua Grunt Petalburg Woods'];
+    const [, Croagunk,] = OpposingTrainer('Team Aqua Grunt Petalburg Woods');
     const { Starly } = getBox();
 
     let state = create1v1BattleState(Starly, Croagunk);
@@ -146,18 +146,35 @@ Ability: Hyper Cutter
     belch = result.find(r => r.move.move.name === 'Belch');
     expect(belch?.finalScore).toBeGreaterThan(0);
   });
+
+  it("Fake out", () => {
+    const [, Croagunk,] = OpposingTrainer('Team Aqua Grunt Petalburg Woods');
+    const { Turtwig } = getBox();
+
+    const actions = getCpuActionsFor1v1(Croagunk, Turtwig);
+    expect(actions.find(a => a.type === 'move' && a.move.move.name === 'Fake Out'))
+      .toBePossibleAction({
+        type: 'move',
+        pokemon: Croagunk,
+        move: {
+          move: 'Fake Out',
+          target: { type: 'opponent', slot: 0 }
+        },
+        probability: 1
+      });
+  });
 });
 
 function getCpuActionsFor1v1(cpuPokemon: Pokemon, playerPokemon: Pokemon): PossibleAction[] {
   const state = new BattleFieldState(
     new PlayerTrainer(
-      [new PokemonPosition(playerPokemon)],
+      [new PokemonPosition(playerPokemon, true)],
       [],
     ),
     new CpuTrainer(
-      [new PokemonPosition(cpuPokemon)],
+      [new PokemonPosition(cpuPokemon, true)],
       [],
-      ),
+    ),
     new Field()
   );
   return getCpuPossibleActions(state, state.cpu.active[0], state.player.active, state.cpu.active);

--- a/src/extensions/simulator/phases/battle/execute-move.spec.ts
+++ b/src/extensions/simulator/phases/battle/execute-move.spec.ts
@@ -8,14 +8,14 @@ import { calculateMoveResult } from '../../moveScoring';
 import { executeMove } from './execute-move';
 import { cpuRng, playerRng } from '../../../configuration';
 import { getBox } from '../../playthrough/museum.collection';
-import { Trainers } from '../../../trainer-sets';
+import { OpposingTrainer } from '../../../trainer-sets';
 
 const RunAndBun = 8;
 inGen(RunAndBun, ({ gen, calculate, Pokemon, Move }) => {
   describe('executeMove', () => {
     describe(`Berries`, () => {
       it('Salac Berry', () => {
-        const [, Croagunk,] = Trainers['Team Aqua Grunt Petalburg Woods'];
+        const [, Croagunk,] = OpposingTrainer('Team Aqua Grunt Petalburg Woods');
         const { Starly } = getBox();
 
         let result = executeMove(Starly, Croagunk, 'Aerial Ace', new Field(), playerRng);
@@ -27,7 +27,7 @@ inGen(RunAndBun, ({ gen, calculate, Pokemon, Move }) => {
     describe(`Defender abilities`, () => {
       it ('Cotton Down', () => {
         const { Gossifleur } = getBox();
-        const [_, Clobbopus ] = Trainers['Triathlete Mikey'];
+        const [_, Clobbopus ] = OpposingTrainer('Triathlete Mikey');
         let executionResult = executeMove(Clobbopus, Gossifleur, 'Rock Smash', new Field(), cpuRng);
         expect(executionResult.attacker.boosts.spe).toBe(-1);
       });
@@ -36,7 +36,7 @@ inGen(RunAndBun, ({ gen, calculate, Pokemon, Move }) => {
     describe('Move effects', () => {
       it('Rock smash', () => {
         const { Gossifleur } = getBox();
-        const [_, Clobbopus ] = Trainers['Triathlete Mikey'];
+        const [_, Clobbopus ] = OpposingTrainer('Triathlete Mikey');
         let executionResult = executeMove(Clobbopus, Gossifleur, 'Rock Smash', new Field(), cpuRng);
         expect(executionResult.defender.boosts.def).toBe(-1);
       })

--- a/src/extensions/simulator/phases/battle/player-move-selection.spec.ts
+++ b/src/extensions/simulator/phases/battle/player-move-selection.spec.ts
@@ -10,7 +10,7 @@ import { getPlayerPossibleActions } from './player-move-selection';
 import { isMoveAction, PossibleAction } from './move-selection.contracts';
 import { BattleFieldState, CpuTrainer, PlayerTrainer, PokemonPosition } from '../../moveScoring.contracts';
 import { getBox } from '../../playthrough/museum.collection';
-import { Trainers } from '../../../trainer-sets';
+import { OpposingTrainer } from '../../../trainer-sets';
 
 describe('Player Move Selection', () => {
   describe('Mega evolution', () => {
@@ -36,7 +36,7 @@ Level: 100
   describe('Switches', () => {
     test('Any time switching', () => {
       let { Gossifleur, Turtwig, Starly, Poochyena } = getBox();
-      let [Grubbin, Pineco, Sizzlipede] = Trainers['Bug Catcher Rick'];
+      let [Grubbin, Pineco, Sizzlipede] = OpposingTrainer('Bug Catcher Rick');
 
       // Grubbin = Grubbin.clone({ curHP: 0 });
       let state = new BattleFieldState(

--- a/src/extensions/simulator/phases/switching/cpu-switch-in.ts
+++ b/src/extensions/simulator/phases/switching/cpu-switch-in.ts
@@ -4,6 +4,7 @@ import { calculateAllMoves, findHighestDamageMove, getCpuMoveConsiderations, get
 import { SwitchAction } from "../battle/move-selection.contracts";
 import { executeSwitch, popFromParty } from "./execute-switch";
 import { PokemonReplacer } from "../../battle-field-state-visitor";
+import { getFinalSpeed } from "../../utils";
 
 const generation = Generations.get(8);
 
@@ -57,10 +58,12 @@ export function chooseSwitchIn(cpuParty: Pokemon[], seenPlayerMon: Pokemon, stat
         let cpuDamageResults = calculateAllMoves(generation, cpuPokemon, seenPlayerMon, state.cpuField);
         let cpuAssumedPlayerMove = findHighestDamageMove(getDamageRanges(playerDamageResults));
         let consideredMoves = getCpuMoveConsiderations(cpuDamageResults, cpuAssumedPlayerMove, state);
+        const finalAISpeed = getFinalSpeed(cpuPokemon, state.cpuField, state.cpuSide);
+        const finalPlayerSpeed = getFinalSpeed(seenPlayerMon, state.playerField, state.playerSide);
         
         return {
             pokemon: cpuPokemon,
-            aiIsFaster: cpuPokemon.stats.spe >= seenPlayerMon.stats.spe,
+            aiIsFaster: finalAISpeed >= finalPlayerSpeed,
             aiOHKOs: consideredMoves.some(m => m.aiWillOHKOPlayer),
             playerOHKOs: consideredMoves.some(m => m.playerWillKOAI),
             aiOutdamagesPlayer: consideredMoves.some(m => m.aiOutdamagesPlayer),

--- a/src/extensions/simulator/phases/turn-end/end-of-turn-effects.ts
+++ b/src/extensions/simulator/phases/turn-end/end-of-turn-effects.ts
@@ -1,0 +1,55 @@
+import { ActivePokemon, BattleFieldState, PokemonPosition } from "../../moveScoring.contracts";
+import { applyBoost, damagePokemonWithPercentageOfMaxHp } from "../../utils";
+import { visitActivePokemonInSpeedOrder } from "../../battle-field-state-visitor";
+
+export function applyEndOfTurnEffects(state: BattleFieldState): BattleFieldState {
+  state = state.clone();
+
+  visitActivePokemonInSpeedOrder(state, {
+    visitActivePokemon(state, pokemon, field) {
+      state = applyEndOfTurnEffect(state, pokemon);
+    },
+  });
+
+  return state;
+}
+
+type Participant  = { self: PokemonPosition, ally?: PokemonPosition, opponents?: PokemonPosition[] };
+export function applyEndOfTurnEffect(state: BattleFieldState, pokemon: PokemonPosition): BattleFieldState {
+  state = state.clone();
+  let participant: Participant;
+  if (state.player.getActivePokemon(pokemon.pokemon)) {
+    participant = { self: pokemon, ally: state.player.active.find(p => !p.pokemon.equals(pokemon.pokemon)), opponents: state.cpu.active };
+  }
+  else {
+    participant = { self: pokemon, ally: state.cpu.active.find(p => !p.pokemon.equals(pokemon.pokemon)), opponents: state.player.active };
+  }
+    
+  applyEffectToField(participant.self, state);
+  applyEffectToSelf(participant.self, participant.opponents!);
+  participant.opponents?.forEach(opponent => applyEffectToTarget(participant.self, opponent));
+  return state;
+}
+
+function applyEffectToSelf(source: ActivePokemon, opponents: ActivePokemon[]): void {
+  switch(source.pokemon.status) {
+    case 'brn':
+      damagePokemonWithPercentageOfMaxHp(source.pokemon, 1/16);
+      break;
+    case 'psn':
+      damagePokemonWithPercentageOfMaxHp(source.pokemon, 1/8);
+      break;
+    case 'tox':
+      damagePokemonWithPercentageOfMaxHp(source.pokemon, source.pokemon.toxicCounter/16);
+      source.pokemon.toxicCounter++;
+      break;
+  }
+}
+
+function applyEffectToTarget(source: ActivePokemon, target: ActivePokemon): void {
+  
+}
+
+function applyEffectToField(source: ActivePokemon, state: BattleFieldState): void {
+  
+}

--- a/src/extensions/simulator/phases/turn-start/field-hazards.ts
+++ b/src/extensions/simulator/phases/turn-start/field-hazards.ts
@@ -2,7 +2,7 @@ import { Side } from "@smogon/calc/src/field";
 import { ActivePokemon, BattleFieldState } from "../../moveScoring.contracts";
 import { visitActivePokemonInSpeedOrder } from "../../battle-field-state-visitor";
 import { Pokemon } from "@smogon/calc";
-import { getTypeEffectiveness } from "../../utils";
+import { applyBoost, applyExternalBoost, damagePokemonWithPercentageOfMaxHp, getTypeEffectiveness } from "../../utils";
 
 export function applyFieldHazards(state: BattleFieldState): BattleFieldState {
     state = state.clone();   
@@ -23,6 +23,10 @@ function applyOrClearHazardOnSide(activePokemon: ActivePokemon, side: Side): voi
         let effectiveness = getTypeEffectiveness('Rock', activePokemon.pokemon);
         let pctLost =  effectiveness * 1/8;
         activePokemon.pokemon = damagePokemonWithPercentageOfMaxHp(activePokemon.pokemon, pctLost);
+    }
+
+    if (side.isStickyWebs && !activePokemon.pokemon.hasType('Flying')) {
+        applyExternalBoost(activePokemon.pokemon, 'spe', -1);
     }
 
     if (side.spikes && !(activePokemon.pokemon.hasAbility('Levitate') || activePokemon.pokemon.hasType('Flying'))) {
@@ -49,9 +53,4 @@ function applyOrClearHazardOnSide(activePokemon: ActivePokemon, side: Side): voi
     //             activePokemon.pokemon.toxicCounter = 1;
     //     }
     // }
-}
-
-function damagePokemonWithPercentageOfMaxHp(pokemon: Pokemon, percentage: number): Pokemon {
-    let damageToTake = Math.floor(pokemon.maxHP() * percentage);
-    return pokemon.clone({ curHP: Math.max(pokemon.curHP() - damageToTake) });
 }

--- a/src/extensions/simulator/playthrough/museum.collection.ts
+++ b/src/extensions/simulator/playthrough/museum.collection.ts
@@ -1,8 +1,362 @@
 import { Pokemon } from "@smogon/calc";
 import { gen } from "../../configuration";
 import { PokemonSet } from "../../trainer-sets.types";
+import { convertStats } from "../helper";
 
-const collection = { "Default": { "customSets": { "Vivillon": { "Custom Set": { "ability": "Compound Eyes", "level": 91, "ivs": { "hp": 16, "at": 16, "df": 17, "sa": 28, "sd": 0, "sp": 23 }, "moves": ["Hurricane", "Protect", "Sleep Powder", "Powder"], "nature": "Gentle", "isCustomSet": true } }, "Kingdra": { "Custom Set": { "ability": "Swift Swim", "level": 91, "ivs": { "hp": 4, "at": 28, "df": 20, "sa": 15, "sd": 28, "sp": 1 }, "moves": ["Octazooka", "Dragon Pulse", "Ice Beam", "Hydro Pump"], "nature": "Jolly", "isCustomSet": true } }, "Tsareena": { "Custom Set": { "ability": "Sweet Veil", "level": 91, "ivs": { "hp": 12, "at": 27, "df": 20, "sa": 7, "sd": 20, "sp": 30 }, "moves": ["Trop Kick", "Rapid Spin", "Magical Leaf", "Power Whip"], "nature": "Hardy", "isCustomSet": true } }, "Musharna": { "Custom Set": { "ability": "Synchronize", "level": 91, "ivs": { "hp": 3, "at": 24, "df": 3, "sa": 0, "sd": 26, "sp": 26 }, "moves": ["Psychic", "Moonblast", "Psyshock", "Moonlight"], "nature": "Naughty", "isCustomSet": true } }, "Salazzle": { "Custom Set": { "ability": "Corrosion", "level": 91, "ivs": { "hp": 20, "at": 28, "df": 23, "sa": 20, "sd": 11 }, "moves": ["Flamethrower", "Sludge Bomb", "Toxic", "Encore"], "nature": "Hardy", "isCustomSet": true } }, "Ampharos": { "Custom Set": { "ability": "Static", "level": 91, "ivs": { "hp": 8, "at": 3, "df": 28, "sa": 13, "sd": 20, "sp": 10 }, "moves": ["Brick Break", "Dragon Pulse", "Thunderbolt", "Power Gem"], "nature": "Sassy", "isCustomSet": true } }, "Infernape": { "Custom Set": { "ability": "Vital Spirit", "level": 91, "ivs": { "df": 23, "sa": 30, "sd": 16 }, "moves": ["Overheat", "Mach Punch", "Close Combat", "Fake Out"], "nature": "Naive", "item": "Charcoal", "isCustomSet": true } }, "Seismitoad": { "Custom Set": { "ability": "Swift Swim", "level": 91, "ivs": { "hp": 10, "at": 24, "df": 4, "sa": 10, "sd": 19, "sp": 11 }, "moves": ["Mud Shot", "Brick Break", "Liquidation", "Earth Power"], "nature": "Calm", "isCustomSet": true } }, "Carracosta": { "Custom Set": { "ability": "Solid Rock", "level": 76, "ivs": { "hp": 30, "at": 9, "df": 21, "sa": 6, "sd": 14, "sp": 25 }, "moves": ["Rock Slide", "Knock Off", "Aqua Jet", "Protect"], "nature": "Naughty", "isCustomSet": true } }, "Walrein": { "Custom Set": { "ability": "Thick Fat", "level": 91, "ivs": { "hp": 8, "at": 15, "df": 21, "sa": 9, "sd": 14, "sp": 3 }, "moves": ["Frost Breath", "Icy Wind", "Freeze-Dry", "Super Fang"], "nature": "Modest", "isCustomSet": true } }, "Aggron": { "Custom Set": { "ability": "Rock Head", "level": 91, "ivs": { "hp": 29, "at": 24, "df": 18, "sa": 3, "sd": 24, "sp": 23 }, "moves": ["Earthquake", "Rock Tomb", "Head Smash", "Heavy Slam"], "nature": "Hardy", "item": "Wide Lens", "isCustomSet": true } }, "Cloyster": { "Custom Set": { "ability": "Skill Link", "level": 91, "ivs": { "hp": 5, "at": 27, "df": 13, "sa": 21, "sd": 10, "sp": 18 }, "moves": ["Rapid Spin", "Ice Shard", "Icicle Spear", "Rock Blast"], "nature": "Lax", "isCustomSet": true } }, "Gliscor": { "Custom Set": { "ability": "Hyper Cutter", "level": 91, "ivs": { "hp": 23, "at": 20, "df": 16, "sa": 7, "sd": 7, "sp": 2 }, "moves": ["Acrobatics", "Knock Off", "Earthquake", "U-turn"], "nature": "Quiet", "isCustomSet": true } }, "Corviknight": { "Custom Set": { "ability": "Unnerve", "level": 91, "ivs": { "hp": 13, "at": 2, "df": 16, "sa": 23, "sd": 21, "sp": 14 }, "moves": ["Brave Bird", "Roost", "Feather Dance", "Defog"], "nature": "Calm", "isCustomSet": true } }, "Excadrill": { "Custom Set": { "ability": "Sand Force", "level": 91, "ivs": { "hp": 23, "at": 9, "df": 5, "sa": 0, "sd": 29, "sp": 10 }, "moves": ["Earthquake", "Iron Head", "High Horsepower", "Rapid Spin"], "nature": "Naive", "item": "Assault Vest", "isCustomSet": true } }, "Flygon": { "Custom Set": { "ability": "Levitate", "level": 91, "ivs": { "hp": 29, "at": 14, "df": 12, "sa": 4, "sd": 12, "sp": 22 }, "moves": ["Draco Meteor", "First Impression", "U-turn", "Stomping Tantrum"], "nature": "Relaxed", "isCustomSet": true } }, "Tyrantrum": { "Custom Set": { "ability": "Strong Jaw", "level": 91, "ivs": { "df": 17, "sa": 6 }, "moves": ["Dragon Claw", "Rock Slide", "Crunch", "Earthquake"], "nature": "Sassy", "isCustomSet": true } }, "Toxtricity-Low-Key": { "Custom Set": { "ability": "Punk Rock", "level": 91, "ivs": { "hp": 21, "at": 0, "df": 5, "sa": 6, "sd": 11, "sp": 7 }, "moves": ["Overdrive", "Sludge Wave", "Boomburst", "Acid Spray"], "nature": "Impish", "isCustomSet": true } }, "Perrserker": { "Custom Set": { "ability": "Battle Armor", "level": 91, "ivs": { "hp": 7, "at": 2, "df": 8, "sa": 8, "sd": 18, "sp": 3 }, "moves": ["Iron Head", "Bullet Punch", "Foul Play", "Brick Break"], "nature": "Lax", "isCustomSet": true } }, "Torkoal": { "Custom Set": { "ability": "Shell Armor", "level": 91, "ivs": { "hp": 30, "at": 8, "df": 26, "sa": 24, "sd": 21, "sp": 12 }, "moves": ["Heat Wave", "Rapid Spin", "Flamethrower", "Protect"], "nature": "Jolly", "isCustomSet": true } }, "Turtonator": { "Custom Set": { "ability": "Shell Armor", "level": 91, "ivs": { "hp": 22, "at": 18, "df": 2, "sa": 28, "sd": 26, "sp": 18 }, "moves": ["Flamethrower", "Dragon Pulse", "Rapid Spin"], "nature": "Lonely", "isCustomSet": true } }, "Swampert": { "Custom Set": { "ability": "Torrent", "level": 91, "ivs": { "hp": 3, "at": 22, "df": 24, "sa": 7, "sd": 0, "sp": 2 }, "moves": ["Earthquake", "Liquidation", "Protect", "Rock Slide"], "nature": "Naughty", "isCustomSet": true } }, "Araquanid": { "Custom Set": { "ability": "Water Bubble", "level": 91, "ivs": { "hp": 24, "df": 8, "sa": 26, "sd": 19, "sp": 19 }, "moves": ["Liquidation", "Lunge", "Leech Life", "Soak"], "nature": "Naughty", "isCustomSet": true } }, "Muk-Alola": { "Custom Set": { "ability": "Poison Touch", "level": 91, "ivs": { "hp": 12, "at": 9, "df": 24, "sa": 12, "sd": 7, "sp": 28 }, "moves": ["Gunk Shot", "Knock Off", "Earthquake"], "nature": "Gentle", "isCustomSet": true } }, "Barraskewda": { "Custom Set": { "ability": "Swift Swim", "level": 91, "ivs": { "hp": 22, "at": 17, "df": 13, "sa": 21, "sd": 5, "sp": 5 }, "moves": ["Liquidation", "Close Combat", "Flip Turn", "Brick Break"], "nature": "Naive", "isCustomSet": true } }, "Lanturn": { "Custom Set": { "ability": "Volt Absorb", "level": 91, "ivs": { "at": 1, "df": 9, "sa": 5, "sd": 5, "sp": 13 }, "moves": ["Thunderbolt", "Surf", "Hydro Pump", "Ice Beam"], "nature": "Careful", "isCustomSet": true } }, "Basculegion": { "Custom Set": { "ability": "Swift Swim", "level": 91, "ivs": { "hp": 21, "at": 30, "df": 25, "sa": 22, "sd": 22, "sp": 3 }, "moves": ["Poltergeist", "Liquidation", "Psychic Fangs", "Superpower"], "nature": "Mild", "isCustomSet": true } }, "Primarina": { "Custom Set": { "ability": "Torrent", "level": 91, "ivs": { "hp": 19, "df": 5, "sa": 15, "sd": 28, "sp": 4 }, "moves": ["Draining Kiss", "Flip Turn", "Surf", "Encore"], "nature": "Quiet", "isCustomSet": true } }, "Aggron-Mega": { "Custom Set": { "ability": "Filter", "level": 91, "ivs": { "hp": 29, "at": 24, "df": 18, "sa": 3, "sd": 24, "sp": 23 }, "moves": ["Earthquake", "Rock Tomb", "Head Smash", "Heavy Slam"], "nature": "Hardy", "isCustomSet": true } }, "Ampharos-Mega": { "Custom Set": { "ability": "Mold Breaker", "level": 91, "ivs": { "hp": 8, "at": 3, "df": 28, "sa": 13, "sd": 20, "sp": 10 }, "moves": ["Brick Break", "Dragon Pulse", "Thunderbolt", "Power Gem"], "nature": "Sassy", "isCustomSet": true } }, "Gyarados": { "Custom Set": { "ability": "Intimidate", "level": 91, "ivs": { "hp": 24, "at": 24, "df": 24, "sa": 16, "sd": 29, "sp": 23 }, "moves": ["Waterfall", "Ice Fang", "Crunch", "Scale Shot"], "nature": "Serious", "isCustomSet": true } }, "Slowbro": { "Custom Set": { "ability": "Own Tempo", "level": 91, "ivs": { "hp": 0, "at": 0, "sa": 13, "sd": 7, "sp": 8 }, "moves": ["Psychic", "Surf", "Slack Off", "Future Sight"], "nature": "Quirky", "isCustomSet": true } }, "Kingler": { "Custom Set": { "ability": "Shell Armor", "level": 91, "ivs": { "hp": 11, "at": 18, "df": 11, "sa": 6, "sd": 9, "sp": 16 }, "moves": ["Crabhammer", "X-Scissor", "Ice Hammer", "Hammer Arm"], "nature": "Quirky", "isCustomSet": true } }, "Golisopod": { "Custom Set": { "ability": "Emergency Exit", "level": 91, "ivs": { "hp": 14, "at": 0, "df": 12, "sa": 25, "sd": 20, "sp": 6 }, "moves": ["First Impression", "Liquidation", "Leech Life", "Sucker Punch"], "nature": "Careful", "isCustomSet": true } }, "Gardevoir": { "Custom Set": { "ability": "Synchronize", "level": 91, "ivs": { "hp": 13, "at": 15, "df": 10, "sa": 30, "sd": 11, "sp": 18 }, "moves": ["Psychic", "Moonblast", "Dream Eater", "Hypnosis"], "nature": "Quiet", "isCustomSet": true } }, "Crobat": { "Custom Set": { "ability": "Inner Focus", "level": 91, "ivs": { "hp": 5, "at": 19, "df": 5, "sa": 27, "sd": 1, "sp": 13 }, "moves": ["Brave Bird", "Sludge Bomb", "Leech Life", "Cross Poison"], "nature": "Quiet", "isCustomSet": true } }, "Milotic": { "Custom Set": { "ability": "Marvel Scale", "level": 91, "ivs": { "hp": 26, "at": 17, "df": 0, "sa": 17, "sd": 20 }, "moves": ["Surf", "Dragon Pulse", "Hydro Pump", "Recover"], "nature": "Timid", "item": "Flame Orb", "isCustomSet": true } }, "Dragapult": { "Custom Set": { "ability": "Infiltrator", "level": 91, "ivs": { "hp": 26, "at": 25, "df": 28, "sa": 19, "sd": 17, "sp": 6 }, "moves": ["Dragon Darts", "Draco Meteor", "Sucker Punch", "Phantom Force"], "nature": "Adamant", "item": "Dragon Fang", "isCustomSet": true } }, "Blastoise": { "Custom Set": { "ability": "Torrent", "level": 91, "ivs": { "hp": 6, "at": 27, "df": 23, "sa": 9, "sd": 16, "sp": 10 }, "moves": ["Razor Shell", "Ice Beam", "Hydro Pump", "Surf"], "nature": "Bashful", "isCustomSet": true } }, "Dragonite": { "Custom Set": { "ability": "Inner Focus", "level": 91, "ivs": { "hp": 15, "at": 4, "df": 10, "sa": 6, "sd": 16, "sp": 28 }, "moves": ["Draco Meteor", "Dual Wingbeat", "Extreme Speed", "Dragon Claw"], "nature": "Docile", "isCustomSet": true } }, "Overqwil": { "Custom Set": { "ability": "Intimidate", "level": 91, "ivs": { "hp": 5, "at": 9, "df": 9, "sa": 7, "sd": 15, "sp": 29 }, "moves": ["Gunk Shot", "Throat Chop", "Liquidation"], "nature": "Impish", "isCustomSet": true } }, "Sneasler": { "Custom Set": { "ability": "Inner Focus", "level": 91, "ivs": { "hp": 15, "at": 22, "df": 19, "sa": 8, "sd": 4, "sp": 28 }, "moves": ["Fake Out", "Gunk Shot", "Close Combat", "Knock Off"], "nature": "Bold", "isCustomSet": true } }, "Ursaluna": { "Custom Set": { "ability": "Guts", "level": 91, "ivs": { "hp": 17, "df": 21, "sa": 28, "sd": 8, "sp": 8 }, "moves": ["High Horsepower", "Earthquake", "Facade", "Yawn"], "nature": "Careful", "item": "Flame Orb", "isCustomSet": true } }, "Urshifu": { "Custom Set": { "ability": "Unseen Fist", "level": 91, "ivs": { "sa": 21, "sd": 23 }, "moves": ["Wicked Blow", "Sucker Punch", "Close Combat", "Iron Head"], "nature": "Naive", "item": "Life Orb", "isCustomSet": true } }, "Beedrill": { "Custom Set": { "ability": "Sniper", "level": 91, "ivs": { "hp": 26, "at": 11, "df": 19, "sa": 19, "sd": 3, "sp": 14 }, "moves": ["Drill Run", "Leech Life", "Poison Jab", "U-turn"], "nature": "Calm", "isCustomSet": true } }, "Beedrill-Mega": { "Custom Set": { "ability": "Adaptability", "level": 91, "ivs": { "hp": 26, "at": 11, "df": 19, "sa": 19, "sd": 3, "sp": 14 }, "moves": ["Drill Run", "Leech Life", "Poison Jab", "U-turn"], "nature": "Calm", "isCustomSet": true } }, "Cradily": { "Custom Set": { "ability": "Suction Cups", "level": 91, "ivs": { "hp": 12, "at": 3, "df": 25, "sa": 22, "sd": 26, "sp": 20 }, "moves": ["Mirror Coat", "Energy Ball", "Power Whip", "Power Gem"], "nature": "Impish", "isCustomSet": true } }, "Grimmsnarl": { "Custom Set": { "ability": "Prankster", "level": 91, "ivs": { "hp": 25, "at": 9, "df": 12, "sa": 19, "sd": 22, "sp": 23 }, "moves": ["Foul Play", "Spirit Break", "Play Rough", "Hammer Arm"], "nature": "Careful", "item": "Sitrus Berry", "isCustomSet": true } }, "Starmie": { "Custom Set": { "ability": "Natural Cure", "level": 91, "ivs": { "hp": 4, "at": 24, "df": 3, "sa": 19, "sd": 18, "sp": 0 }, "moves": ["Psychic", "Hydro Pump", "Recover", "Ice Beam"], "nature": "Careful", "isCustomSet": true } }, "Aerodactyl": { "Custom Set": { "ability": "Rock Head", "level": 91, "ivs": { "hp": 24, "at": 11, "df": 14, "sa": 9, "sd": 19, "sp": 3 }, "moves": ["Double-Edge", "Dual Wingbeat", "Tailwind", "Stone Edge"], "nature": "Bashful", "isCustomSet": true } }, "Aerodactyl-Mega": { "Custom Set": { "ability": "Tough Claws", "level": 91, "ivs": { "hp": 24, "at": 11, "df": 14, "sa": 9, "sd": 19, "sp": 3 }, "moves": ["Double-Edge", "Dual Wingbeat", "Tailwind", "Stone Edge"], "nature": "Bashful", "isCustomSet": true } }, "Armaldo": { "Custom Set": { "ability": "Battle Armor", "level": 91, "ivs": { "hp": 24, "at": 10, "df": 21, "sa": 16, "sd": 28, "sp": 18 }, "moves": ["Rapid Spin", "Leech Life", "Rock Blast", "Stone Edge"], "nature": "Hardy", "isCustomSet": true } } }, "party": ["Tsareena (Custom Set)", "Aggron-Mega (Custom Set)"] }, "Simulator": { "customSets": { "Turtwig": { "Custom Set": { "ability": "Shell Armor", "level": 12, "ivs": { "sa": 8 }, "moves": ["Absorb", "Bite", "Growl", "Confide"], "nature": "Hardy", "isCustomSet": true } }, "Starly": { "Custom Set": { "ability": "Keen Eye", "level": 12, "ivs": { "hp": 25, "at": 15, "df": 15, "sa": 14, "sd": 5, "sp": 28 }, "moves": ["Tackle", "Growl", "Quick Attack", "Aerial Ace"], "nature": "Jolly", "isCustomSet": true } }, "Surskit": { "Custom Set": { "ability": "Swift Swim", "level": 12, "ivs": { "hp": 29, "at": 4, "df": 8, "sa": 2, "sd": 4, "sp": 9 }, "moves": ["Bubble Beam", "Quick Attack"], "nature": "Bashful", "isCustomSet": true } }, "Gossifleur": { "Custom Set": { "ability": "Cotton Down", "level": 12, "ivs": { "hp": 3, "at": 9, "df": 13, "sa": 8, "sd": 30, "sp": 6 }, "moves": ["Leafage", "Magical Leaf"], "nature": "Modest", "isCustomSet": true } }, "Poochyena": { "Custom Set": { "ability": "Run Away", "level": 12, "ivs": { "hp": 15, "at": 17, "df": 18, "sa": 16, "sd": 1, "sp": 30 }, "moves": ["Bite", "Tackle", "Sand Attack", "Baby-Doll Eyes"], "nature": "Adamant", "isCustomSet": true } } }, "party": [] } }
+const collection = {
+    "Default": {
+        "customSets": {
+            "Vivillon": {
+                "Custom Set": {
+                    "ability": "Compound Eyes", "level": 91, "ivs": { "hp": 16, "at": 16, "df": 17, "sa": 28, "sd": 0, "sp": 23 },
+                    "moves": ["Hurricane", "Protect", "Sleep Powder", "Powder"], "nature": "Gentle", "isCustomSet": true
+                }
+            },
+            "Kingdra": {
+                "Custom Set": {
+                    "ability": "Swift Swim", "level": 91, "ivs": { "hp": 4, "at": 28, "df": 20, "sa": 15, "sd": 28, "sp": 1 },
+                    "moves": ["Octazooka", "Dragon Pulse", "Ice Beam", "Hydro Pump"], "nature": "Jolly", "isCustomSet": true
+                }
+            },
+            "Tsareena": {
+                "Custom Set": {
+                    "ability": "Sweet Veil", "level": 91, "ivs": { "hp": 12, "at": 27, "df": 20, "sa": 7, "sd": 20, "sp": 30 },
+                    "moves": ["Trop Kick", "Rapid Spin", "Magical Leaf", "Power Whip"], "nature": "Hardy", "isCustomSet": true
+                }
+            },
+            "Musharna": {
+                "Custom Set": {
+                    "ability": "Synchronize", "level": 91, "ivs": { "hp": 3, "at": 24, "df": 3, "sa": 0, "sd": 26, "sp": 26 },
+                    "moves": ["Psychic", "Moonblast", "Psyshock", "Moonlight"], "nature": "Naughty", "isCustomSet": true
+                }
+            },
+            "Salazzle": {
+                "Custom Set": {
+                    "ability": "Corrosion", "level": 91, "ivs": { "hp": 20, "at": 28, "df": 23, "sa": 20, "sd": 11 },
+                    "moves": ["Flamethrower", "Sludge Bomb", "Toxic", "Encore"], "nature": "Hardy", "isCustomSet": true
+                }
+            },
+            "Ampharos": {
+                "Custom Set": {
+                    "ability": "Static", "level": 91, "ivs": { "hp": 8, "at": 3, "df": 28, "sa": 13, "sd": 20, "sp": 10 },
+                    "moves": ["Brick Break", "Dragon Pulse", "Thunderbolt", "Power Gem"], "nature": "Sassy", "isCustomSet": true
+                }
+            },
+            "Infernape": {
+                "Custom Set": {
+                    "ability": "Vital Spirit", "level": 91, "ivs": { "df": 23, "sa": 30, "sd": 16 },
+                    "moves": ["Overheat", "Mach Punch", "Close Combat", "Fake Out"], "nature": "Naive", "item": "Charcoal", "isCustomSet": true
+                }
+            },
+            "Seismitoad": {
+                "Custom Set": {
+                    "ability": "Swift Swim", "level": 91, "ivs": { "hp": 10, "at": 24, "df": 4, "sa": 10, "sd": 19, "sp": 11 },
+                    "moves": ["Mud Shot", "Brick Break", "Liquidation", "Earth Power"], "nature": "Calm", "isCustomSet": true
+                }
+            },
+            "Carracosta": {
+                "Custom Set": {
+                    "ability": "Solid Rock", "level": 76, "ivs": { "hp": 30, "at": 9, "df": 21, "sa": 6, "sd": 14, "sp": 25 },
+                    "moves": ["Rock Slide", "Knock Off", "Aqua Jet", "Protect"], "nature": "Naughty", "isCustomSet": true
+                }
+            },
+            "Walrein": {
+                "Custom Set": {
+                    "ability": "Thick Fat", "level": 91, "ivs": { "hp": 8, "at": 15, "df": 21, "sa": 9, "sd": 14, "sp": 3 },
+                    "moves": ["Frost Breath", "Icy Wind", "Freeze-Dry", "Super Fang"], "nature": "Modest", "isCustomSet": true
+                }
+            },
+            "Aggron": {
+                "Custom Set": {
+                    "ability": "Rock Head", "level": 91, "ivs": { "hp": 29, "at": 24, "df": 18, "sa": 3, "sd": 24, "sp": 23 },
+                    "moves": ["Earthquake", "Rock Tomb", "Head Smash", "Heavy Slam"], "nature": "Hardy", "item": "Wide Lens", "isCustomSet": true
+                }
+            },
+            "Cloyster": {
+                "Custom Set": {
+                    "ability": "Skill Link", "level": 91, "ivs": { "hp": 5, "at": 27, "df": 13, "sa": 21, "sd": 10, "sp": 18 },
+                    "moves": ["Rapid Spin", "Ice Shard", "Icicle Spear", "Rock Blast"], "nature": "Lax", "isCustomSet": true
+                }
+            },
+            "Gliscor": {
+                "Custom Set": {
+                    "ability": "Hyper Cutter", "level": 91, "ivs": { "hp": 23, "at": 20, "df": 16, "sa": 7, "sd": 7, "sp": 2 },
+                    "moves": ["Acrobatics", "Knock Off", "Earthquake", "U-turn"], "nature": "Quiet", "isCustomSet": true
+                }
+            },
+            "Corviknight": {
+                "Custom Set": {
+                    "ability": "Unnerve", "level": 91, "ivs": { "hp": 13, "at": 2, "df": 16, "sa": 23, "sd": 21, "sp": 14 },
+                    "moves": ["Brave Bird", "Roost", "Feather Dance", "Defog"], "nature": "Calm", "isCustomSet": true
+                }
+            },
+            "Excadrill": {
+                "Custom Set": {
+                    "ability": "Sand Force", "level": 91, "ivs": { "hp": 23, "at": 9, "df": 5, "sa": 0, "sd": 29, "sp": 10 },
+                    "moves": ["Earthquake", "Iron Head", "High Horsepower", "Rapid Spin"], "nature": "Naive", "item": "Assault Vest", "isCustomSet": true
+                }
+            },
+            "Flygon": {
+                "Custom Set": {
+                    "ability": "Levitate", "level": 91, "ivs": { "hp": 29, "at": 14, "df": 12, "sa": 4, "sd": 12, "sp": 22 },
+                    "moves": ["Draco Meteor", "First Impression", "U-turn", "Stomping Tantrum"], "nature": "Relaxed", "isCustomSet": true
+                }
+            },
+            "Tyrantrum": {
+                "Custom Set": {
+                    "ability": "Strong Jaw", "level": 91, "ivs": { "df": 17, "sa": 6 },
+                    "moves": ["Dragon Claw", "Rock Slide", "Crunch", "Earthquake"], "nature": "Sassy", "isCustomSet": true
+                }
+            },
+            "Toxtricity-Low-Key": {
+                "Custom Set": {
+                    "ability": "Punk Rock", "level": 91, "ivs": { "hp": 21, "at": 0, "df": 5, "sa": 6, "sd": 11, "sp": 7 },
+                    "moves": ["Overdrive", "Sludge Wave", "Boomburst", "Acid Spray"], "nature": "Impish", "isCustomSet": true
+                }
+            },
+            "Perrserker": {
+                "Custom Set": {
+                    "ability": "Battle Armor", "level": 91, "ivs": { "hp": 7, "at": 2, "df": 8, "sa": 8, "sd": 18, "sp": 3 },
+                    "moves": ["Iron Head", "Bullet Punch", "Foul Play", "Brick Break"], "nature": "Lax", "isCustomSet": true
+                }
+            },
+            "Torkoal": {
+                "Custom Set": {
+                    "ability": "Shell Armor", "level": 91, "ivs": { "hp": 30, "at": 8, "df": 26, "sa": 24, "sd": 21, "sp": 12 },
+                    "moves": ["Heat Wave", "Rapid Spin", "Flamethrower", "Protect"], "nature": "Jolly", "isCustomSet": true
+                }
+            },
+            "Turtonator": {
+                "Custom Set": {
+                    "ability": "Shell Armor", "level": 91, "ivs": { "hp": 22, "at": 18, "df": 2, "sa": 28, "sd": 26, "sp": 18 },
+                    "moves": ["Flamethrower", "Dragon Pulse", "Rapid Spin"], "nature": "Lonely", "isCustomSet": true
+                }
+            },
+            "Swampert": {
+                "Custom Set": {
+                    "ability": "Torrent", "level": 91, "ivs": { "hp": 3, "at": 22, "df": 24, "sa": 7, "sd": 0, "sp": 2 },
+                    "moves": ["Earthquake", "Liquidation", "Protect", "Rock Slide"], "nature": "Naughty", "isCustomSet": true
+                }
+            },
+            "Araquanid": {
+                "Custom Set": {
+                    "ability": "Water Bubble", "level": 91, "ivs": { "hp": 24, "df": 8, "sa": 26, "sd": 19, "sp": 19 },
+                    "moves": ["Liquidation", "Lunge", "Leech Life", "Soak"], "nature": "Naughty", "isCustomSet": true
+                }
+            },
+            "Muk-Alola": {
+                "Custom Set": {
+                    "ability": "Poison Touch", "level": 91, "ivs": { "hp": 12, "at": 9, "df": 24, "sa": 12, "sd": 7, "sp": 28 },
+                    "moves": ["Gunk Shot", "Knock Off", "Earthquake"], "nature": "Gentle", "isCustomSet": true
+                }
+            },
+            "Barraskewda": {
+                "Custom Set": {
+                    "ability": "Swift Swim", "level": 91, "ivs": { "hp": 22, "at": 17, "df": 13, "sa": 21, "sd": 5, "sp": 5 },
+                    "moves": ["Liquidation", "Close Combat", "Flip Turn", "Brick Break"], "nature": "Naive", "isCustomSet": true
+                }
+            },
+            "Lanturn": {
+                "Custom Set": {
+                    "ability": "Volt Absorb", "level": 91, "ivs": { "at": 1, "df": 9, "sa": 5, "sd": 5, "sp": 13 },
+                    "moves": ["Thunderbolt", "Surf", "Hydro Pump", "Ice Beam"], "nature": "Careful", "isCustomSet": true
+                }
+            },
+            "Basculegion": {
+                "Custom Set": {
+                    "ability": "Swift Swim", "level": 91, "ivs": { "hp": 21, "at": 30, "df": 25, "sa": 22, "sd": 22, "sp": 3 },
+                    "moves": ["Poltergeist", "Liquidation", "Psychic Fangs", "Superpower"], "nature": "Mild", "isCustomSet": true
+                }
+            },
+            "Primarina": {
+                "Custom Set": {
+                    "ability": "Torrent", "level": 91, "ivs": { "hp": 19, "df": 5, "sa": 15, "sd": 28, "sp": 4 },
+                    "moves": ["Draining Kiss", "Flip Turn", "Surf", "Encore"], "nature": "Quiet", "isCustomSet": true
+                }
+            },
+            "Aggron-Mega": {
+                "Custom Set": {
+                    "ability": "Filter", "level": 91, "ivs": { "hp": 29, "at": 24, "df": 18, "sa": 3, "sd": 24, "sp": 23 },
+                    "moves": ["Earthquake", "Rock Tomb", "Head Smash", "Heavy Slam"], "nature": "Hardy", "isCustomSet": true
+                }
+            },
+            "Ampharos-Mega": {
+                "Custom Set": {
+                    "ability": "Mold Breaker", "level": 91, "ivs": { "hp": 8, "at": 3, "df": 28, "sa": 13, "sd": 20, "sp": 10 },
+                    "moves": ["Brick Break", "Dragon Pulse", "Thunderbolt", "Power Gem"], "nature": "Sassy", "isCustomSet": true
+                }
+            },
+            "Gyarados": {
+                "Custom Set": {
+                    "ability": "Intimidate", "level": 91, "ivs": { "hp": 24, "at": 24, "df": 24, "sa": 16, "sd": 29, "sp": 23 },
+                    "moves": ["Waterfall", "Ice Fang", "Crunch", "Scale Shot"], "nature": "Serious", "isCustomSet": true
+                }
+            },
+            "Slowbro": {
+                "Custom Set": {
+                    "ability": "Own Tempo", "level": 91, "ivs": { "hp": 0, "at": 0, "sa": 13, "sd": 7, "sp": 8 },
+                    "moves": ["Psychic", "Surf", "Slack Off", "Future Sight"], "nature": "Quirky", "isCustomSet": true
+                }
+            },
+            "Kingler": {
+                "Custom Set": {
+                    "ability": "Shell Armor", "level": 91, "ivs": { "hp": 11, "at": 18, "df": 11, "sa": 6, "sd": 9, "sp": 16 },
+                    "moves": ["Crabhammer", "X-Scissor", "Ice Hammer", "Hammer Arm"], "nature": "Quirky", "isCustomSet": true
+                }
+            },
+            "Golisopod": {
+                "Custom Set": {
+                    "ability": "Emergency Exit", "level": 91, "ivs": { "hp": 14, "at": 0, "df": 12, "sa": 25, "sd": 20, "sp": 6 },
+                    "moves": ["First Impression", "Liquidation", "Leech Life", "Sucker Punch"], "nature": "Careful", "isCustomSet": true
+                }
+            },
+            "Gardevoir": {
+                "Custom Set": {
+                    "ability": "Synchronize", "level": 91, "ivs": { "hp": 13, "at": 15, "df": 10, "sa": 30, "sd": 11, "sp": 18 },
+                    "moves": ["Psychic", "Moonblast", "Dream Eater", "Hypnosis"], "nature": "Quiet", "isCustomSet": true
+                }
+            },
+            "Crobat": {
+                "Custom Set": {
+                    "ability": "Inner Focus", "level": 91, "ivs": { "hp": 5, "at": 19, "df": 5, "sa": 27, "sd": 1, "sp": 13 },
+                    "moves": ["Brave Bird", "Sludge Bomb", "Leech Life", "Cross Poison"], "nature": "Quiet", "isCustomSet": true
+                }
+            },
+            "Milotic": {
+                "Custom Set": {
+                    "ability": "Marvel Scale", "level": 91, "ivs": { "hp": 26, "at": 17, "df": 0, "sa": 17, "sd": 20 },
+                    "moves": ["Surf", "Dragon Pulse", "Hydro Pump", "Recover"], "nature": "Timid", "item": "Flame Orb", "isCustomSet": true
+                }
+            },
+            "Dragapult": {
+                "Custom Set": {
+                    "ability": "Infiltrator", "level": 91, "ivs": { "hp": 26, "at": 25, "df": 28, "sa": 19, "sd": 17, "sp": 6 },
+                    "moves": ["Dragon Darts", "Draco Meteor", "Sucker Punch", "Phantom Force"], "nature": "Adamant", "item": "Dragon Fang", "isCustomSet": true
+                }
+            },
+            "Blastoise": {
+                "Custom Set": {
+                    "ability": "Torrent", "level": 91, "ivs": { "hp": 6, "at": 27, "df": 23, "sa": 9, "sd": 16, "sp": 10 },
+                    "moves": ["Razor Shell", "Ice Beam", "Hydro Pump", "Surf"], "nature": "Bashful", "isCustomSet": true
+                }
+            },
+            "Dragonite": {
+                "Custom Set": {
+                    "ability": "Inner Focus", "level": 91, "ivs": { "hp": 15, "at": 4, "df": 10, "sa": 6, "sd": 16, "sp": 28 },
+                    "moves": ["Draco Meteor", "Dual Wingbeat", "Extreme Speed", "Dragon Claw"], "nature": "Docile", "isCustomSet": true
+                }
+            },
+            "Overqwil": {
+                "Custom Set": {
+                    "ability": "Intimidate", "level": 91, "ivs": { "hp": 5, "at": 9, "df": 9, "sa": 7, "sd": 15, "sp": 29 },
+                    "moves": ["Gunk Shot", "Throat Chop", "Liquidation"], "nature": "Impish", "isCustomSet": true
+                }
+            },
+            "Sneasler": {
+                "Custom Set": {
+                    "ability": "Inner Focus", "level": 91, "ivs": { "hp": 15, "at": 22, "df": 19, "sa": 8, "sd": 4, "sp": 28 },
+                    "moves": ["Fake Out", "Gunk Shot", "Close Combat", "Knock Off"], "nature": "Bold", "isCustomSet": true
+                }
+            },
+            "Ursaluna": {
+                "Custom Set": {
+                    "ability": "Guts", "level": 91, "ivs": { "hp": 17, "df": 21, "sa": 28, "sd": 8, "sp": 8 },
+                    "moves": ["High Horsepower", "Earthquake", "Facade", "Yawn"], "nature": "Careful", "item": "Flame Orb", "isCustomSet": true
+                }
+            },
+            "Urshifu": {
+                "Custom Set": {
+                    "ability": "Unseen Fist", "level": 91, "ivs": { "sa": 21, "sd": 23 },
+                    "moves": ["Wicked Blow", "Sucker Punch", "Close Combat", "Iron Head"], "nature": "Naive", "item": "Life Orb", "isCustomSet": true
+                }
+            },
+            "Beedrill": {
+                "Custom Set": {
+                    "ability": "Sniper", "level": 91, "ivs": { "hp": 26, "at": 11, "df": 19, "sa": 19, "sd": 3, "sp": 14 },
+                    "moves": ["Drill Run", "Leech Life", "Poison Jab", "U-turn"], "nature": "Calm", "isCustomSet": true
+                }
+            },
+            "Beedrill-Mega": {
+                "Custom Set": {
+                    "ability": "Adaptability", "level": 91, "ivs": { "hp": 26, "at": 11, "df": 19, "sa": 19, "sd": 3, "sp": 14 },
+                    "moves": ["Drill Run", "Leech Life", "Poison Jab", "U-turn"], "nature": "Calm", "isCustomSet": true
+                }
+            },
+            "Cradily": {
+                "Custom Set": {
+                    "ability": "Suction Cups", "level": 91, "ivs": { "hp": 12, "at": 3, "df": 25, "sa": 22, "sd": 26, "sp": 20 },
+                    "moves": ["Mirror Coat", "Energy Ball", "Power Whip", "Power Gem"], "nature": "Impish", "isCustomSet": true
+                }
+            },
+            "Grimmsnarl": {
+                "Custom Set": {
+                    "ability": "Prankster", "level": 91, "ivs": { "hp": 25, "at": 9, "df": 12, "sa": 19, "sd": 22, "sp": 23 },
+                    "moves": ["Foul Play", "Spirit Break", "Play Rough", "Hammer Arm"], "nature": "Careful", "item": "Sitrus Berry", "isCustomSet": true
+                }
+            },
+            "Starmie": {
+                "Custom Set": {
+                    "ability": "Natural Cure", "level": 91, "ivs": { "hp": 4, "at": 24, "df": 3, "sa": 19, "sd": 18, "sp": 0 },
+                    "moves": ["Psychic", "Hydro Pump", "Recover", "Ice Beam"], "nature": "Careful", "isCustomSet": true
+                }
+            },
+            "Aerodactyl": {
+                "Custom Set": {
+                    "ability": "Rock Head", "level": 91, "ivs": { "hp": 24, "at": 11, "df": 14, "sa": 9, "sd": 19, "sp": 3 },
+                    "moves": ["Double-Edge", "Dual Wingbeat", "Tailwind", "Stone Edge"], "nature": "Bashful", "isCustomSet": true
+                }
+            },
+            "Aerodactyl-Mega": {
+                "Custom Set": {
+                    "ability": "Tough Claws", "level": 91, "ivs": { "hp": 24, "at": 11, "df": 14, "sa": 9, "sd": 19, "sp": 3 },
+                    "moves": ["Double-Edge", "Dual Wingbeat", "Tailwind", "Stone Edge"], "nature": "Bashful", "isCustomSet": true
+                }
+            },
+            "Armaldo": {
+                "Custom Set": {
+                    "ability": "Battle Armor", "level": 91, "ivs": { "hp": 24, "at": 10, "df": 21, "sa": 16, "sd": 28, "sp": 18 },
+                    "moves": ["Rapid Spin", "Leech Life", "Rock Blast", "Stone Edge"], "nature": "Hardy", "isCustomSet": true
+                }
+            }
+        },
+        "party": ["Tsareena (Custom Set)", "Aggron-Mega (Custom Set)"]
+    },
+    "Simulator": {
+        "customSets": {
+            "Turtwig": {
+                "Custom Set": {
+                    "ability": "Shell Armor", "level": 12, "ivs": { "sa": 8 },
+                    "moves": ["Absorb", "Bite", "Growl", "Confide"], "nature": "Hardy", "isCustomSet": true
+                }
+            },
+            "Starly": {
+                "Custom Set": {
+                    "ability": "Keen Eye", "level": 12, "ivs": { "hp": 25, "at": 15, "df": 15, "sa": 14, "sd": 5, "sp": 28 },
+                    "moves": ["Tackle", "Growl", "Quick Attack", "Aerial Ace"], "nature": "Jolly", "isCustomSet": true
+                }
+            },
+            "Surskit": {
+                "Custom Set": {
+                    "ability": "Swift Swim", "level": 12, "ivs": { "hp": 29, "at": 4, "df": 8, "sa": 2, "sd": 4, "sp": 9 },
+                    "moves": ["Bubble Beam", "Quick Attack"], "nature": "Bashful", "isCustomSet": true
+                }
+            },
+            "Gossifleur": {
+                "Custom Set": {
+                    "ability": "Cotton Down", "level": 12, "ivs": { "hp": 3, "at": 9, "df": 13, "sa": 8, "sd": 30, "sp": 6 },
+                    "moves": ["Leafage", "Magical Leaf"], "nature": "Modest", "isCustomSet": true
+                }
+            },
+            "Poochyena": {
+                "Custom Set": {
+                    "ability": "Run Away", "level": 12, "ivs": { "hp": 15, "at": 17, "df": 18, "sa": 16, "sd": 1, "sp": 30 },
+                    "moves": ["Bite", "Tackle", "Sand Attack", "Baby-Doll Eyes"], "nature": "Adamant", "isCustomSet": true
+                }
+            }
+        },
+        "party": []
+    }
+}
 const customSets = collection.Simulator.customSets;
 
 type Pokes = keyof typeof customSets;
@@ -19,13 +373,13 @@ export function getBox(): { [pokemon in Pokes]: Pokemon } {
             {
                 ability: set.ability,
                 level: set.level,
-                ivs: set.ivs,
+                ivs: convertStats(set.ivs),
                 moves: set.moves,
                 nature: set.nature,
                 item: set.item,
             }
         );
     }
-    
+
     return Box;
 }

--- a/src/extensions/simulator/playthrough/playthrough.spec.ts
+++ b/src/extensions/simulator/playthrough/playthrough.spec.ts
@@ -6,13 +6,13 @@ import { expectTeam, usingHeuristics } from '../test-helper';
 import { BasicScoring, IntuitionScoring } from '../phases/battle/player-move-selection-strategy';
 import { findPlayerWinningPath, printDecisionTree } from '../path-finder';
 import { getBox } from './museum.collection';
-import { Trainers } from '../../trainer-sets';
+import { OpposingTrainer } from '../../trainer-sets';
 import { attack, PlannedPlayerActionProvider, playerRng, switchTo } from '../../configuration';
 import { ItemName } from '@smogon/calc/dist/data/interface';
 import { executeMove } from '../phases/battle/execute-move';
 
 describe('Actual playthrough tests', () => {
-  describe('Aqua Grunt Split', () => {
+  describe('Team Aqua Grunt Petalburg Woods', () => {
     test('Route 103 - Rival May', () => {
       let [Torchic, Turtwig] = importTeam(`
 Torchic
@@ -82,7 +82,7 @@ IVs: 20 HP / 27 Atk / 8 SpA
     });
 
     test('Bug Catcher Rick', () => {
-      const cpu = Trainers['Bug Catcher Rick'];
+      const cpu = OpposingTrainer('Bug Catcher Rick');
 
       const { Turtwig, Gossifleur, Poochyena, Starly, Surskit } = getBox();
       const state = new BattleFieldState(
@@ -100,7 +100,7 @@ IVs: 20 HP / 27 Atk / 8 SpA
     });
 
     test('Triathlete Mikey', () => {
-      const cpu = Trainers['Triathlete Mikey'];
+      const cpu = OpposingTrainer('Triathlete Mikey');
 
       const { Turtwig, Gossifleur, Poochyena, Starly, Surskit } = getBox();
       const state = new BattleFieldState(
@@ -136,7 +136,41 @@ IVs: 20 HP / 27 Atk / 8 SpA
     });
 
     test('Fisherman Darian', () => {
-      const cpu = Trainers['Fisherman Darian'];
+      const cpu = OpposingTrainer('Fisherman Darian');
+
+      const { Turtwig, Gossifleur, Poochyena, Starly, Surskit } = getBox();
+      const state = new BattleFieldState(
+        new PlayerTrainer([new PokemonPosition(Starly, true)], [
+          Gossifleur,
+          Poochyena,
+          Turtwig,
+          Surskit,
+        ]),
+        new CpuTrainer([], cpu),
+        new Field());
+
+      Turtwig.item = 'Oran Berry' as any;
+      Gossifleur.item = 'Oran Berry' as any;
+      Poochyena.item = 'Oran Berry' as any;
+      Starly.item = 'Oran Berry' as any;
+      Surskit.item = 'Oran Berry' as any;
+      // usingHeuristics({ playerActionProvider: new PlannedPlayerActionProvider([
+      //   [ attack(Starly, 'Quick Attack') ],
+      //   [ attack(Starly, 'Aerial Ace') ],
+      //   [ attack(Starly, 'Quick Attack') ],
+      //   [ attack(Starly, 'Aerial Ace') ],
+      //   [ switchTo(Gossifleur) ],
+      //   [ attack(Gossifleur, 'Leafage') ],
+      //   [ attack(Gossifleur, 'Leafage') ],
+      // ]) }, () => {
+      const path = findPlayerWinningPath(state);
+      expect(path).not.toBeNull();
+      // expect(printDecisionTree(path!)).toBe('');
+      // });
+    });
+
+    test('Team Aqua Grunt Petalburg Woods', () => {
+      const cpu = OpposingTrainer('Team Aqua Grunt Petalburg Woods');
 
       const { Turtwig, Gossifleur, Poochyena, Starly, Surskit } = getBox();
       const state = new BattleFieldState(

--- a/src/extensions/simulator/switchStrategy.cpu.ts
+++ b/src/extensions/simulator/switchStrategy.cpu.ts
@@ -2,6 +2,7 @@ import { Pokemon } from "@smogon/calc";
 import { BattleFieldState, SwitchStrategy } from "./moveScoring.contracts";
 import { BattleSimulator } from "./simulator";
 import { gen } from "../configuration";
+import { getFinalSpeed } from "./utils";
 
 interface SwitchInConsideration {
     pokemon: Pokemon;
@@ -24,13 +25,13 @@ export class CpuSwitchStrategy implements SwitchStrategy {
             let playerMonAfterBattle = resultState.player.active[0];
             let cpuDamage = result.turnOutcomes[0].actions.find(a => a.attacker.equals(remainingMon))!.highestRollDamage;
             let playerDamage = result.turnOutcomes[0].actions.find(a => !a.attacker.equals(remainingMon))!.highestRollDamage;
-            
+            let playerSpeed = getFinalSpeed(playerMonAfterBattle.pokemon, state.playerField, state.playerSide);
             return {
                 pokemon: remainingMon,
                 getsKOd: cpuMonAfterBattle.pokemon.curHP() === 0,
                 kosOpponent: playerMonAfterBattle.pokemon.curHP() === 0,
                 outDamages: cpuDamage > playerDamage,
-                isFaster: remainingMon.stats.spe >= state.player.active[0].pokemon.stats.spe
+                isFaster: remainingMon.stats.spe >= playerSpeed // TODO: Does the AI see things like tailwind?
             };
         });
 

--- a/src/extensions/simulator/turn-state.ts
+++ b/src/extensions/simulator/turn-state.ts
@@ -1,10 +1,13 @@
-import { BattleFieldState } from "./moveScoring.contracts";
+import { BattleFieldState, PokemonPosition } from "./moveScoring.contracts";
 import { applyPlayerSwitchIns, applyCpuSwitchIns } from "./phases/switching";
 import { applyStartOfTurnAbilities } from "./phases/turn-start/start-of-turn-abilities";
 import { applyFieldHazards } from "./phases/turn-start/field-hazards";
 import { determineMoveOrderAndExecute } from "./phases/battle/determine-move-order-and-execute";
 import { ActionLogEntry } from "./phases/battle/move-selection.contracts";
 import { applyEndOfTurnAbilities } from "./phases/turn-end/end-of-turn-abilities";
+import { applyEndOfTurnEffects } from "./phases/turn-end/end-of-turn-effects";
+import { BattleFieldStateRewriter, PokemonPositionReplacer } from "./battle-field-state-visitor";
+import { Pokemon } from "@smogon/calc";
 
 export type PossibleBattleFieldState = { type: 'possible', probability: number, state: BattleFieldState, history: ActionLogEntry[] };
 export type BattleFieldStateTransform = (state: BattleFieldState) => BattleFieldState | BattleFieldState[] | PossibleBattleFieldState[];
@@ -39,12 +42,25 @@ export function runTurn(state: BattleFieldState): PossibleBattleFieldState[] {
         applyFieldHazards,
         applyStartOfTurnAbilities,
         determineMoveOrderAndExecute,
-        // applyEndOfTurnEffects,
+        applyEndOfTurnEffects,
         applyEndOfTurnAbilities,
+        endTurn
     ];
 
     let turnEnd = applyTransforms(nextState, transforms);
     return turnEnd;
+}
+
+function endTurn(state: BattleFieldState): BattleFieldState {
+    class PokemonPositionReplacer extends BattleFieldStateRewriter {    
+        public override visitActivePokemon(pokemon: PokemonPosition): PokemonPosition {
+            const newPosition = pokemon.clone();
+            newPosition.firstTurnOut = false;
+            return newPosition;
+        }
+    }
+    
+    return new PokemonPositionReplacer().visitState(state);
 }
 
 function applyAbilities(state: BattleFieldState): BattleFieldState {

--- a/src/extensions/simulator/utils.ts
+++ b/src/extensions/simulator/utils.ts
@@ -1,10 +1,16 @@
-import { A, Pokemon, toID } from "@smogon/calc";
+import { A, Field, Pokemon, Side, toID } from "@smogon/calc";
 import { StatsTable } from "@smogon/calc/src";
 import { TypeName } from "@smogon/calc/src/data/interface";
 import { getActiveSets, saveActiveSets } from "../core/storage";
 import { CustomSets, PokemonSet } from "../core/storage.contracts";
 import { gen } from "../configuration";
 import { hasLifeSavingAbility, hasLifeSavingItem } from "./moveScoring";
+import { MoveName } from "@smogon/calc/dist/data/interface";
+import { getFinalSpeed as calcGetFinalSpeed } from "@smogon/calc/src/mechanics/util";
+
+export function canFlinch(move: MoveName): boolean {
+	return ['Air Slash', 'Astonish', 'Bite', 'Bone Club', 'Bulldoze', 'Dark Pulse', 'Dragon Rush', 'Extrasensory', 'Fire Fang', 'Headbutt', 'Heart Stamp', 'Ice Fang', 'Iron Head', 'Needle Arm', 'Rock Slide', 'Rock Tomb', 'Rolling Kick', 'Rollout', 'Sky Attack', 'Stomp', 'Waterfall', 'Zen Headbutt'].includes(move);
+}
 
 export function curHPPercentage(pokemon: A.Pokemon): number {
     return pokemon.curHP() / pokemon.maxHP();
@@ -23,6 +29,18 @@ export function getHPAfterDamage(pokemon: Pokemon, currentHp: number, maxHp: num
 
 export function isFainted(pokemon: A.Pokemon): boolean {
     return pokemon.curHP() <= 0;
+}
+
+export function getFinalSpeed(pokemon: A.Pokemon, field: Field, side: Side): number {
+	return calcGetFinalSpeed(gen, pokemon as any, field, side);
+}
+
+/** Applies an external (not from self) boost to stats. Doesn't impact Clear Body pokemon */
+export function applyExternalBoost(pokemon: Pokemon, kind: keyof StatsTable, modifier: number): void {
+	if (pokemon.hasAbility('Clear Body') && modifier < 0)
+		return;
+	
+	applyBoost(pokemon.stats, kind, modifier);
 }
 
 export function applyBoost(stats: StatsTable, kind: keyof StatsTable, modifier: number): void {
@@ -74,4 +92,9 @@ export function updateSets(setCallback: (set: PokemonSet, setName: string, pokem
     if (updated) {
 	    saveActiveSets(updated);
     }
+}
+
+export function damagePokemonWithPercentageOfMaxHp(pokemon: Pokemon, percentage: number): Pokemon {
+    let damageToTake = Math.floor(pokemon.maxHP() * percentage);
+    return pokemon.clone({ curHP: Math.max(pokemon.curHP() - damageToTake) });
 }

--- a/src/extensions/trainer-sets.ts
+++ b/src/extensions/trainer-sets.ts
@@ -3,7 +3,8 @@ import { gen } from "./configuration";
 import { TrainerSets } from "./trainer-sets.data";
 import { PokemonSet } from "./trainer-sets.types";
 
-export const Trainers = initializeTrainerSets();
+export const OpposingTrainer = (trainerName: keyof ReturnType<typeof initializeTrainerSets>) => initializeTrainerSets()[trainerName];
+
 export const PokemonIndexToTrainerMap = (() => {
   const trainerPokemonIndexMap = new Map<number, string>();
   for (const [pokemonName, trainerSets] of Object.entries(TrainerSets)) {


### PR DESCRIPTION
Update executeMove to account for move status infliction, address dynamic speed, and fix fake out scoring. Next step is to try to account for branching possibilities due to damage range overlaps. There's really too much in this PR, but... I'll let myself have one :)

* Sticky webs
* Move and ability status effects (ex: poison touch, stun spore)
* Make CPU trainers not modifiable
* Add more hooks for RNG
* Print decision tree in execution order
* Dynamic speed